### PR TITLE
Update README with local server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@ RuneDream is a simple endless runner prototype. Control the Wisp Dragon with key
 ## Play
 
 Open `index.html` in a modern browser. The game is designed with mobile in mind, so touch controls can be added later.
+
+To avoid asset-loading issues, start a local web server in the project root:
+
+```bash
+python3 -m http.server
+```
+
+Then open <http://localhost:8000> in your browser. Opening the file directly may show only a blank canvas.


### PR DESCRIPTION
## Summary
- document launching a local server to prevent blank-canvas issues

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6878008ac89c832c8cda9a5b207cae87