### PR TITLE
Add launch screen and open game window

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ RuneDream is a simple endless runner prototype. Control the Wisp Dragon with key
 
 ## Play
 
-Open `index.html` in a modern browser. The game is designed with mobile in mind, so touch controls can be added later.
+Open `index.html` in a modern browser. You'll see a launch screen with a **Start Game** button. Clicking it opens the game in its own window. The game is designed with mobile in mind, so touch controls can be added later.
 
 To avoid asset-loading issues, start a local web server in the project root:
 

--- a/css/style.css
+++ b/css/style.css
@@ -1,14 +1,35 @@
 body {
   margin: 0;
-  overflow: hidden;
   background: #89ABE3;
   font-family: sans-serif;
+}
+
+#landing {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+#startBtn {
+  padding: 10px 20px;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+#gameContainer {
+  position: relative;
+  width: 800px;
+  height: 450px;
+  margin: 20px auto;
 }
 
 #gameCanvas {
   display: block;
   background: #d0e0ff;
-  margin: 0 auto;
+  width: 100%;
+  height: 100%;
 }
 
 #hud {

--- a/game.html
+++ b/game.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RuneDream</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <div id="gameContainer">
+    <canvas id="gameCanvas" width="800" height="450"></canvas>
+    <div id="hud">
+      <span id="distance">0m</span>
+      <span id="coins">0</span>
+    </div>
+  </div>
+  <script src="js/game.js"></script>
+  <script>
+    window.addEventListener('load', () => {
+      startGame();
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -7,11 +7,14 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <canvas id="gameCanvas" width="800" height="450"></canvas>
-  <div id="hud">
-    <span id="distance">0m</span>
-    <span id="coins">0</span>
+  <div id="landing">
+    <h1>RuneDream</h1>
+    <button id="startBtn">Start Game</button>
   </div>
-  <script src="js/game.js"></script>
+  <script>
+    document.getElementById('startBtn').addEventListener('click', () => {
+      window.open('game.html', 'RuneDreamGame', 'width=820,height=510');
+    });
+  </script>
 </body>
 </html>

--- a/js/game.js
+++ b/js/game.js
@@ -92,8 +92,9 @@ const GAME = {
 };
 
 function init() {
-  canvas.width = 800;
-  canvas.height = 450;
+  const container = document.getElementById('gameContainer');
+  canvas.width = container.clientWidth;
+  canvas.height = container.clientHeight;
   GAME.player.y = canvas.height - 100;
   GAME.player.jumpCharges = 2;
   GAME.player.dashCharges = 2;
@@ -289,4 +290,8 @@ function restart() {
   GAME.player.y = getGroundLevel(GAME.player.x) - 10;
 }
 
-loadImages(init);
+function startGame() {
+  loadImages(init);
+}
+
+window.startGame = startGame;


### PR DESCRIPTION
## Summary
- create `game.html` for the gameplay canvas
- add new landing page with Start Game button
- style landing screen and game container
- allow game to be started programmatically from button
- update README instructions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6878015aad30832c8603910bf3161468