### PR TITLE
Add main screen and in-page game

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -12,7 +12,11 @@ body {
   justify-content: center;
 }
 
-#startBtn {
+#startBtn,
+#playBtn,
+#shopBtn,
+#backBtn,
+#returnBtn {
   padding: 10px 20px;
   font-size: 24px;
   cursor: pointer;
@@ -43,4 +47,27 @@ body {
 
 #hud span {
   margin-right: 20px;
+}
+
+#gameOver {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+}
+
+#shop {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }

--- a/game.html
+++ b/game.html
@@ -13,11 +13,18 @@
       <span id="distance">0m</span>
       <span id="coins">0</span>
     </div>
+    <div id="gameOver">
+      <p>You lost!</p>
+      <button id="returnBtn">Main Menu</button>
+    </div>
   </div>
   <script src="js/game.js"></script>
   <script>
     window.addEventListener('load', () => {
       startGame();
+      document.getElementById('returnBtn').addEventListener('click', () => {
+        window.location.href = 'index.html';
+      });
     });
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -9,11 +9,15 @@
 <body>
   <div id="landing">
     <h1>RuneDream</h1>
-    <button id="startBtn">Start Game</button>
+    <button id="playBtn">Play Game</button>
+    <button id="shopBtn">Upgrade Shop</button>
   </div>
   <script>
-    document.getElementById('startBtn').addEventListener('click', () => {
-      window.open('game.html', 'RuneDreamGame', 'width=820,height=510');
+    document.getElementById('playBtn').addEventListener('click', () => {
+      window.location.href = 'game.html';
+    });
+    document.getElementById('shopBtn').addEventListener('click', () => {
+      window.location.href = 'upgrade.html';
     });
   </script>
 </body>

--- a/js/game.js
+++ b/js/game.js
@@ -2,6 +2,7 @@ const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
 const distanceEl = document.getElementById('distance');
 const coinsEl = document.getElementById('coins');
+const gameOverEl = document.getElementById('gameOver');
 
 const ASSETS = {
   run: [
@@ -84,6 +85,7 @@ function init() {
   canvas.width = container.clientWidth;
   canvas.height = container.clientHeight;
   GAME.player.y = canvas.height - 100;
+  gameOverEl.style.display = 'none';
   GAME.player.jumpCharges = 2;
   GAME.player.dashCharges = 2;
   let x = 0;
@@ -178,7 +180,14 @@ function update() {
     const py = GAME.player.y - GAME.player.height + 10;
     const playerImg = GAME.player.dash > 0 ? images[ASSETS.dash] : images[ASSETS.run[GAME.player.frame]];
     const obsImg = images[o.type === 'orange' ? ASSETS.orange : ASSETS.black];
-    if (isPixelCollision(playerImg, px, py, GAME.player.width, GAME.player.height, obsImg, o.x, o.y, 96, 96)) {
+    const buffer = 10;
+    if (
+      px + buffer < o.x + 96 - buffer &&
+      px + GAME.player.width - buffer > o.x + buffer &&
+      py + buffer < o.y + 96 - buffer &&
+      py + GAME.player.height - buffer > o.y + buffer &&
+      isPixelCollision(playerImg, px, py, GAME.player.width, GAME.player.height, obsImg, o.x, o.y, 96, 96)
+    ) {
       if (o.type === 'orange' && GAME.player.dash > 0) {
         o.hit = true;
         GAME.player.coins += 5;
@@ -229,7 +238,15 @@ function draw() {
       GAME.player.frameTime = 0;
     }
   }
-  ctx.drawImage(sprite, GAME.player.x, GAME.player.y - GAME.player.height + 10, GAME.player.width, GAME.player.height);
+  if (GAME.player.dash > 0) {
+    ctx.save();
+    ctx.translate(GAME.player.x + GAME.player.width, GAME.player.y - GAME.player.height + 10);
+    ctx.scale(-1, 1);
+    ctx.drawImage(sprite, 0, 0, GAME.player.width, GAME.player.height);
+    ctx.restore();
+  } else {
+    ctx.drawImage(sprite, GAME.player.x, GAME.player.y - GAME.player.height + 10, GAME.player.width, GAME.player.height);
+  }
 }
 
 function loop() {
@@ -239,17 +256,7 @@ function loop() {
 }
 
 function gameOverPrompt() {
-  const spend = confirm('Spend 10 coins to continue?');
-  if (spend && GAME.player.coins >= 10) {
-    GAME.player.coins -= 10;
-    GAME.player.alive = true;
-    GAME.gameOverHandled = false;
-  } else {
-    const again = confirm('Play again?');
-    if (again) {
-      restart();
-    }
-  }
+  gameOverEl.style.display = 'flex';
 }
 
 function restart() {
@@ -270,6 +277,7 @@ function restart() {
     x = last.x + last.width + last.gap;
   }
   GAME.player.y = getGroundLevel(GAME.player.x) - 10;
+  gameOverEl.style.display = 'none';
 }
 
 function startGame() {

--- a/upgrade.html
+++ b/upgrade.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RuneDream - Upgrades</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <div id="shop">
+    <h1>Upgrade Shop</h1>
+    <ul>
+      <li>Extra Jump - 50 coins</li>
+      <li>Dash Recharge - 30 coins</li>
+      <li>Armor - 100 coins</li>
+    </ul>
+    <button id="backBtn">Back</button>
+  </div>
+  <script>
+    document.getElementById('backBtn').addEventListener('click', () => {
+      window.location.href = 'index.html';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- stop opening the game in a new window
- add main menu with Play and Upgrade Shop buttons
- create simple upgrade shop page
- show in-game overlay when the player dies
- flip dash sprite and tweak collision checks

## Testing
- `npm test` *(fails: ENOENT)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68781545af5c832cb64e7f57513d7586