### PR TITLE
Allow dashing through orange star obstacles

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ RuneDream is a simple endless runner prototype. Control the Wisp Dragon with key
 - **Jump**: `Space` or `ArrowUp`
 - **Dash**: `Control` or `X`
 
+## Obstacles
+
+Orange stars can be destroyed by dashing through them. If you are dashing when you collide with one, it will explode and disappear, awarding extra coins. Touching an orange star without dashing is fatal. Black stars are always deadly and cannot be destroyed, even when dashing.
+
 ## Play
 
 Open `index.html` in a modern browser. You'll see a launch screen with a **Start Game** button. Clicking it opens the game in its own window. The game is designed with mobile in mind, so touch controls can be added later.

--- a/js/game.js
+++ b/js/game.js
@@ -221,26 +221,30 @@ function update() {
   GAME.obstacles.forEach(o => {
     if (o.hit) return;
     const dashActive = GAME.player.dash > 0 || GAME.player.dashBuffer > 0;
-    const px = GAME.player.x + (dashActive ? 48 : 0);
+    const px = GAME.player.x;
     const py = GAME.player.y - GAME.player.height + 10;
     const playerImg = dashActive ? images[ASSETS.dash] : images[ASSETS.run[GAME.player.frame]];
     const obsImg = images[o.type === 'orange' ? ASSETS.orange : ASSETS.black];
     const buffer = dashActive ? 0 : 10;
-    if (
+
+    const boxHit =
       px + buffer < o.x + 96 - buffer &&
       px + GAME.player.width - buffer > o.x + buffer &&
       py + buffer < o.y + 96 - buffer &&
-      py + GAME.player.height - buffer > o.y + buffer &&
-      isPixelCollision(playerImg, px, py, GAME.player.width, GAME.player.height, obsImg, o.x, o.y, 96, 96)
-    ) {
-      if (o.type === 'orange' && dashActive) {
-        o.hit = true;
-        o.timer = 10;
-        GAME.player.coins += 5;
-      } else {
-        GAME.player.alive = false;
-        GAME.deathByObstacle = true;
-      }
+      py + GAME.player.height - buffer > o.y + buffer;
+
+    if (!boxHit) return;
+
+    if (o.type === 'orange' && dashActive) {
+      o.hit = true;
+      o.timer = 10;
+      GAME.player.coins += 5;
+      return;
+    }
+
+    if (isPixelCollision(playerImg, px, py, GAME.player.width, GAME.player.height, obsImg, o.x, o.y, 96, 96)) {
+      GAME.player.alive = false;
+      GAME.deathByObstacle = true;
     }
   });
 


### PR DESCRIPTION
## Summary
- adjust collision detection so orange stars break when hit while dashing
- describe obstacle behavior in the README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6878212ea724832c89a1d00885be09d2