### PR TITLE
Add refund option and new upgrades

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -71,3 +71,8 @@ body {
   align-items: center;
   justify-content: center;
 }
+
+.stars {
+  color: gold;
+  margin-left: 5px;
+}

--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
       localStorage.setItem('jumpLevel', '0');
       localStorage.setItem('dashLevel', '0');
       localStorage.setItem('shieldLevel', '0');
+      localStorage.setItem('jumpHeightLevel', '0');
+      localStorage.setItem('dashDurationLevel', '0');
+      localStorage.setItem('extraLifeLevel', '0');
       localStorage.setItem('upgradeCost', '25');
       alert('Progress reset!');
     });

--- a/js/game.js
+++ b/js/game.js
@@ -76,9 +76,11 @@ const GAME = {
     dashBuffer: 0,
     dashCharges: 2,
     maxDashCharges: 2,
+    dashDuration: 25,
     dashY: 0,
     jumpCharges: 2,
     maxJumpCharges: 2,
+    jumpStrength: 12,
     coins: 0,
     hp: 1,
     maxHp: 1,
@@ -98,7 +100,11 @@ function init() {
   GAME.player.coins = parseInt(localStorage.getItem('coins') || '0');
   GAME.player.maxJumpCharges = 2 + parseInt(localStorage.getItem('jumpLevel') || '0');
   GAME.player.maxDashCharges = 2 + parseInt(localStorage.getItem('dashLevel') || '0');
-  GAME.player.maxHp = 1 + parseInt(localStorage.getItem('shieldLevel') || '0');
+  GAME.player.maxHp = 1 +
+    parseInt(localStorage.getItem('shieldLevel') || '0') +
+    parseInt(localStorage.getItem('extraLifeLevel') || '0');
+  GAME.player.jumpStrength = 12 + 2 * parseInt(localStorage.getItem('jumpHeightLevel') || '0');
+  GAME.player.dashDuration = 25 + 5 * parseInt(localStorage.getItem('dashDurationLevel') || '0');
   GAME.player.hp = GAME.player.maxHp;
   coinsEl.textContent = GAME.player.coins;
   GAME.player.y = canvas.height - 210;
@@ -125,12 +131,12 @@ function handleInput(e) {
   if (!GAME.player.alive) return;
   if (e.code === 'ArrowUp' || e.code === 'Space') {
     if (GAME.player.jumpCharges > 0) {
-      GAME.player.vy = -12;
+      GAME.player.vy = -GAME.player.jumpStrength;
       GAME.player.jumpCharges--;
     }
   } else if (e.code === 'ControlLeft' || e.code === 'ControlRight' || e.code === 'KeyX') {
     if (GAME.player.dash <= 0 && GAME.player.dashCharges > 0) {
-      GAME.player.dash = 25;
+      GAME.player.dash = GAME.player.dashDuration;
       GAME.player.dashCharges--;
       GAME.player.dashY = GAME.player.y;
       GAME.player.vy = 0;
@@ -362,7 +368,11 @@ function restart() {
   GAME.player.coins = parseInt(localStorage.getItem('coins') || '0');
   GAME.player.maxJumpCharges = 2 + parseInt(localStorage.getItem('jumpLevel') || '0');
   GAME.player.maxDashCharges = 2 + parseInt(localStorage.getItem('dashLevel') || '0');
-  GAME.player.maxHp = 1 + parseInt(localStorage.getItem('shieldLevel') || '0');
+  GAME.player.maxHp = 1 +
+    parseInt(localStorage.getItem('shieldLevel') || '0') +
+    parseInt(localStorage.getItem('extraLifeLevel') || '0');
+  GAME.player.jumpStrength = 12 + 2 * parseInt(localStorage.getItem('jumpHeightLevel') || '0');
+  GAME.player.dashDuration = 25 + 5 * parseInt(localStorage.getItem('dashDurationLevel') || '0');
   GAME.player.hp = GAME.player.maxHp;
   GAME.player.x = 100;
   coinsEl.textContent = GAME.player.coins;

--- a/js/upgrade.js
+++ b/js/upgrade.js
@@ -3,7 +3,18 @@ const costEls = document.querySelectorAll('.cost');
 const jumpBtn = document.getElementById('jumpBtn');
 const dashBtn = document.getElementById('dashBtn');
 const shieldBtn = document.getElementById('shieldBtn');
+const jumpHeightBtn = document.getElementById('jumpHeightBtn');
+const dashDurationBtn = document.getElementById('dashDurationBtn');
+const lifeBtn = document.getElementById('lifeBtn');
 const backBtn = document.getElementById('backBtn');
+const refundBtn = document.getElementById('refundBtn');
+
+const jumpStars = document.getElementById('jumpStars');
+const dashStars = document.getElementById('dashStars');
+const shieldStars = document.getElementById('shieldStars');
+const jumpHeightStars = document.getElementById('jumpHeightStars');
+const dashDurationStars = document.getElementById('dashDurationStars');
+const lifeStars = document.getElementById('lifeStars');
 
 let coins = parseInt(localStorage.getItem('coins') || '0');
 let upgradeCost = parseInt(localStorage.getItem('upgradeCost') || '25');
@@ -11,6 +22,12 @@ let upgradeCost = parseInt(localStorage.getItem('upgradeCost') || '25');
 function refresh() {
   coinDisplay.textContent = coins;
   costEls.forEach(el => el.textContent = upgradeCost);
+  jumpStars.textContent = '★'.repeat(parseInt(localStorage.getItem('jumpLevel') || '0'));
+  dashStars.textContent = '★'.repeat(parseInt(localStorage.getItem('dashLevel') || '0'));
+  shieldStars.textContent = '★'.repeat(parseInt(localStorage.getItem('shieldLevel') || '0'));
+  jumpHeightStars.textContent = '★'.repeat(parseInt(localStorage.getItem('jumpHeightLevel') || '0'));
+  dashDurationStars.textContent = '★'.repeat(parseInt(localStorage.getItem('dashDurationLevel') || '0'));
+  lifeStars.textContent = '★'.repeat(parseInt(localStorage.getItem('extraLifeLevel') || '0'));
 }
 
 function buy(key) {
@@ -24,9 +41,25 @@ function buy(key) {
   refresh();
 }
 
+function refund() {
+  const purchases = upgradeCost / 25 - 1;
+  if (purchases <= 0) return;
+  const refundAmount = 25 * purchases * (purchases + 1) / 2;
+  coins += refundAmount;
+  localStorage.setItem('coins', coins);
+  upgradeCost = 25;
+  localStorage.setItem('upgradeCost', upgradeCost);
+  ['jumpLevel','dashLevel','shieldLevel','jumpHeightLevel','dashDurationLevel','extraLifeLevel'].forEach(k => localStorage.setItem(k,'0'));
+  refresh();
+}
+
 jumpBtn.addEventListener('click', () => buy('jumpLevel'));
 dashBtn.addEventListener('click', () => buy('dashLevel'));
 shieldBtn.addEventListener('click', () => buy('shieldLevel'));
+jumpHeightBtn.addEventListener('click', () => buy('jumpHeightLevel'));
+dashDurationBtn.addEventListener('click', () => buy('dashDurationLevel'));
+lifeBtn.addEventListener('click', () => buy('extraLifeLevel'));
+refundBtn.addEventListener('click', refund);
 backBtn.addEventListener('click', () => {
   window.location.href = 'index.html';
 });

--- a/upgrade.html
+++ b/upgrade.html
@@ -12,18 +12,31 @@
     <p>Coins: <span id="coinDisplay">0</span></p>
     <ul>
       <li>
-        Add a Jump Charge - <span class="cost"></span> coins
+        Add a Jump Charge <span id="jumpStars" class="stars"></span> - <span class="cost"></span> coins
         <button id="jumpBtn">Buy</button>
       </li>
       <li>
-        Add a Dash Charge - <span class="cost"></span> coins
+        Add a Dash Charge <span id="dashStars" class="stars"></span> - <span class="cost"></span> coins
         <button id="dashBtn">Buy</button>
       </li>
       <li>
-        Add a Shield Charge - <span class="cost"></span> coins
+        Add a Shield Charge <span id="shieldStars" class="stars"></span> - <span class="cost"></span> coins
         <button id="shieldBtn">Buy</button>
       </li>
+      <li>
+        Increase Jump Height <span id="jumpHeightStars" class="stars"></span> - <span class="cost"></span> coins
+        <button id="jumpHeightBtn">Buy</button>
+      </li>
+      <li>
+        Increase Dash Duration <span id="dashDurationStars" class="stars"></span> - <span class="cost"></span> coins
+        <button id="dashDurationBtn">Buy</button>
+      </li>
+      <li>
+        Gain an Extra Life <span id="lifeStars" class="stars"></span> - <span class="cost"></span> coins
+        <button id="lifeBtn">Buy</button>
+      </li>
     </ul>
+    <button id="refundBtn">Refund all Coins</button>
     <button id="backBtn">Back</button>
   </div>
   <script src="js/upgrade.js"></script>


### PR DESCRIPTION
## Summary
- expand upgrade shop with more upgrade types and star indicators
- allow players to refund all coins and reset upgrades
- wire jump height, dash duration and extra life into the game

## Testing
- `node -e "require('./js/upgrade.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687a64bd03a8832c812ee43091f5077e