### PR TITLE
Add splash assets and collision flash

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,6 +4,14 @@ body {
   font-family: sans-serif;
 }
 
+body.landing {
+  background: url("../Title Screen.png") center/cover no-repeat;
+}
+
+body.game {
+  background: url("../Blank Screen.png") center/cover no-repeat;
+}
+
 #landing {
   height: 100vh;
   display: flex;
@@ -19,6 +27,13 @@ body {
 #returnBtn {
   padding: 10px 20px;
   font-size: 24px;
+  cursor: pointer;
+}
+
+.menu-button {
+  width: 300px;
+  height: auto;
+  margin: 10px 0;
   cursor: pointer;
 }
 

--- a/game.html
+++ b/game.html
@@ -6,7 +6,7 @@
   <title>RuneDream</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body class="game">
   <div id="gameContainer">
     <canvas id="gameCanvas" width="800" height="450"></canvas>
     <div id="hud">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>RuneDream</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body class="landing">
   <div id="landing">
     <h1>RuneDream</h1>
     <div id="scores">
@@ -19,10 +19,10 @@
         <ol id="taScoreList"></ol>
       </div>
     </div>
-    <button id="playBtn">Play Game</button>
-    <button id="timeBtn">Time Attack Mode</button>
-    <button id="shopBtn">Upgrade Shop</button>
-    <button id="resetBtn">Reset Progress</button>
+    <img id="playBtn" class="menu-button" src="button_playgame.png" alt="Play Game">
+    <img id="timeBtn" class="menu-button" src="button_timeattack.png" alt="Time Attack Mode">
+    <img id="shopBtn" class="menu-button" src="button_upgradeshop.png" alt="Upgrade Shop">
+    <img id="resetBtn" class="menu-button" src="button_resetprogress.png" alt="Reset Progress">
   </div>
   <script>
     document.getElementById('playBtn').addEventListener('click', () => {

--- a/js/game.js
+++ b/js/game.js
@@ -372,7 +372,7 @@ function update() {
         }
         loseLife('obstacle');
       }
-      if (o.type === 'orange' && !dashActive) {
+      if ((o.type === 'orange' && !dashActive) || o.type === 'black') {
         GAME.flashTimer = 10;
       }
     }


### PR DESCRIPTION
## Summary
- implement landing and game backgrounds
- replace menu buttons with image assets
- show red flash when colliding with black stars

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a7bfce0c0832c8e5c75f7bb7273d2