### PR TITLE
UI tweaks and darker game background

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -18,6 +18,7 @@ body.game {
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  position: relative;
 }
 
 #startBtn,
@@ -37,6 +38,20 @@ body.game {
   cursor: pointer;
 }
 
+#buttonCluster {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#buttonCluster .menu-button {
+  width: 200px;
+  margin: 5px 0;
+}
+
 #gameContainer {
   position: relative;
   width: 800px;
@@ -46,7 +61,9 @@ body.game {
 
 #gameCanvas {
   display: block;
-  background: #d0e0ff;
+  background: #000;
+  transform: scale(1.2);
+  transform-origin: center;
   width: 100%;
   height: 100%;
 }

--- a/index.html
+++ b/index.html
@@ -19,10 +19,12 @@
         <ol id="taScoreList"></ol>
       </div>
     </div>
-    <img id="playBtn" class="menu-button" src="button_playgame.png" alt="Play Game">
-    <img id="timeBtn" class="menu-button" src="button_timeattack.png" alt="Time Attack Mode">
-    <img id="shopBtn" class="menu-button" src="button_upgradeshop.png" alt="Upgrade Shop">
-    <img id="resetBtn" class="menu-button" src="button_resetprogress.png" alt="Reset Progress">
+    <div id="buttonCluster">
+      <img id="playBtn" class="menu-button" src="button_playgame.png" alt="Play Game">
+      <img id="timeBtn" class="menu-button" src="button_timeattack.png" alt="Time Attack Mode">
+      <img id="shopBtn" class="menu-button" src="button_upgradeshop.png" alt="Upgrade Shop">
+      <img id="resetBtn" class="menu-button" src="button_resetprogress.png" alt="Reset Progress">
+    </div>
   </div>
   <script>
     document.getElementById('playBtn').addEventListener('click', () => {

--- a/js/game.js
+++ b/js/game.js
@@ -99,8 +99,8 @@ const GAME = {
     x: 100,
     y: 0,
     vy: 0,
-    width: 64,
-    height: 64,
+    width: 96,
+    height: 96,
     frame: 0,
     frameTime: 0,
     dash: 0,
@@ -387,10 +387,7 @@ function update() {
 function draw() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   // background gradient
-  const grad = ctx.createLinearGradient(0, 0, 0, canvas.height);
-  grad.addColorStop(0, '#89ABE3');
-  grad.addColorStop(1, '#F0F8FF');
-  ctx.fillStyle = grad;
+  ctx.fillStyle = '#000';
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 
   // ground


### PR DESCRIPTION
## Summary
- cluster menu buttons at the top right of the landing page
- style new button cluster in CSS
- darken the game canvas and zoom in slightly
- enlarge player sprite

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a7f2419a4832cae83867ae86cb9de