### PR TITLE
Implement settings page and adjust menu layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,8 +24,7 @@ body.game {
 #startBtn,
 #playBtn,
 #shopBtn,
-#backBtn,
-#returnBtn {
+#backBtn {
   padding: 10px 20px;
   font-size: 24px;
   cursor: pointer;
@@ -61,7 +60,7 @@ body.game {
 
 #gameCanvas {
   display: block;
-  background: #000;
+  background: #d0e0ff;
   transform: scale(1.2);
   transform-origin: center;
   width: 100%;
@@ -94,14 +93,15 @@ body.game {
 #scores {
   width: 100%;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   margin-bottom: 20px;
 }
 
 .scoreTable {
-  width: 45%;
+  width: 15%;
   background: rgba(255,255,255,0.5);
   padding: 10px;
+  margin-right: 10px;
 }
 
 #gameOver {

--- a/game.html
+++ b/game.html
@@ -16,7 +16,7 @@
     <span id="timer">3:00</span>
     <div id="gameOver">
       <p>You lost!</p>
-      <button id="returnBtn">Main Menu</button>
+      <img id="returnBtn" class="menu-button" src="button_return.png" alt="Return">
     </div>
   </div>
   <script src="js/game.js"></script>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
 </head>
 <body class="landing">
   <div id="landing">
-    <h1>RuneDream</h1>
     <div id="scores">
       <div id="normalScores" class="scoreTable">
         <h2>High Scores</h2>
@@ -24,6 +23,8 @@
       <img id="timeBtn" class="menu-button" src="button_timeattack.png" alt="Time Attack Mode">
       <img id="shopBtn" class="menu-button" src="button_upgradeshop.png" alt="Upgrade Shop">
       <img id="resetBtn" class="menu-button" src="button_resetprogress.png" alt="Reset Progress">
+      <img id="settingsBtn" class="menu-button" src="button_settings.png" alt="Settings">
+      <img id="exitBtn" class="menu-button" src="button_exitgame.png" alt="Exit Game">
     </div>
   </div>
   <script>
@@ -35,6 +36,12 @@
     });
     document.getElementById('shopBtn').addEventListener('click', () => {
       window.location.href = 'upgrade.html';
+    });
+    document.getElementById('settingsBtn').addEventListener('click', () => {
+      window.location.href = 'settings.html';
+    });
+    document.getElementById('exitBtn').addEventListener('click', () => {
+      window.close();
     });
     document.getElementById('resetBtn').addEventListener('click', () => {
       localStorage.setItem('coins', '0');

--- a/js/game.js
+++ b/js/game.js
@@ -387,7 +387,10 @@ function update() {
 function draw() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   // background gradient
-  ctx.fillStyle = '#000';
+  const grad = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  grad.addColorStop(0, '#89ABE3');
+  grad.addColorStop(1, '#F0F8FF');
+  ctx.fillStyle = grad;
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 
   // ground

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,22 @@
+const musicSlider = document.getElementById('musicVol');
+const effectSlider = document.getElementById('effectVol');
+const backBtn = document.getElementById('backBtn');
+
+function loadSettings() {
+  musicSlider.value = localStorage.getItem('musicVolume') || '1';
+  effectSlider.value = localStorage.getItem('effectVolume') || '1';
+}
+
+musicSlider.addEventListener('input', () => {
+  localStorage.setItem('musicVolume', musicSlider.value);
+});
+
+effectSlider.addEventListener('input', () => {
+  localStorage.setItem('effectVolume', effectSlider.value);
+});
+
+backBtn.addEventListener('click', () => {
+  window.location.href = 'index.html';
+});
+
+loadSettings();

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RuneDream - Settings</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <div id="settings">
+    <h1>Settings</h1>
+    <label>Music Volume
+      <input type="range" id="musicVol" min="0" max="1" step="0.1">
+    </label>
+    <label>Effects Volume
+      <input type="range" id="effectVol" min="0" max="1" step="0.1">
+    </label>
+    <button id="backBtn">Back</button>
+  </div>
+  <script src="js/settings.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scale back game background change and restore gradient
- remove title text from the landing page
- shrink score tables and align them left
- add Exit Game and Settings menu buttons
- create settings page for volume sliders
- use Return image on game over screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b1690eee8832cac6c90fed0a91fd4