### PR TITLE
Add yellow star obstacle, respawn delay and music

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -39,16 +39,16 @@ body.game {
 
 #buttonCluster {
   position: absolute;
-  top: 20px;
-  right: 20px;
+  top: 10px;
+  right: 10px;
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
 #buttonCluster .menu-button {
-  width: 200px;
-  margin: 5px 0;
+  width: 180px;
+  margin: 2px 0;
 }
 
 #gameContainer {
@@ -117,6 +117,21 @@ body.game {
   align-items: center;
   justify-content: center;
   font-size: 24px;
+}
+
+#respawnMsg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: 32px;
 }
 
 #shop {

--- a/game.html
+++ b/game.html
@@ -18,6 +18,7 @@
       <p>You lost!</p>
       <img id="returnBtn" class="menu-button" src="button_return.png" alt="Return">
     </div>
+    <div id="respawnMsg">Coming back in...</div>
   </div>
   <script src="js/game.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- play `song_Dreamy_Wisps.mp3` during gameplay
- consolidate menu buttons on landing screen
- add a respawn countdown overlay
- implement new yellow star obstacle with break animation

## Testing
- `node --check js/game.js`

------
https://chatgpt.com/codex/tasks/task_e_687b9b07edb0832cb1b2c3d283303fd7