### PR TITLE
Fix mobile visibility and adjust sprite offset

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -56,9 +56,10 @@ body.game {
 
 #gameContainer {
   position: relative;
-  width: 800px;
-  height: 450px;
-  margin: 20px auto;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  overflow: hidden;
 }
 
 #gameCanvas {

--- a/game.html
+++ b/game.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>RuneDream</title>
   <link rel="manifest" href="manifest.json">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>RuneDream</title>
   <link rel="manifest" href="manifest.json">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/js/game.js
+++ b/js/game.js
@@ -31,6 +31,8 @@ const images = {};
 let loaded = 0;
 let total = ASSETS.run.length + 6 + ASSETS.yellowBreak.length;
 
+const DRAW_OFFSET = 35; // lower sprite to compensate for transparent padding
+
 const music = new Audio('song_Dreamy_Wisps.mp3');
 music.loop = true;
 
@@ -439,7 +441,7 @@ function update() {
     if (o.hit) return;
     const dashActive = GAME.player.dash > 0 || GAME.player.dashBuffer > 0;
     const px = GAME.player.x;
-    const py = GAME.player.y - GAME.player.height + 20;
+    const py = GAME.player.y - GAME.player.height + DRAW_OFFSET;
     const playerImg = dashActive ? images[ASSETS.dash] : images[ASSETS.run[GAME.player.frame]];
     const obsImg = images[
       o.type === 'orange'
@@ -561,13 +563,13 @@ function draw() {
   }
   if (GAME.player.dash > 0) {
     ctx.save();
-    ctx.translate(GAME.player.x + GAME.player.width, GAME.player.y - GAME.player.height + 20);
+    ctx.translate(GAME.player.x + GAME.player.width, GAME.player.y - GAME.player.height + DRAW_OFFSET);
     ctx.scale(-1, 1);
     ctx.drawImage(sprite, 0, 0, GAME.player.width, GAME.player.height);
     ctx.restore();
   } else {
     ctx.save();
-    ctx.translate(GAME.player.x + GAME.player.width, GAME.player.y - GAME.player.height + 20);
+    ctx.translate(GAME.player.x + GAME.player.width, GAME.player.y - GAME.player.height + DRAW_OFFSET);
     ctx.scale(-1, 1);
     ctx.drawImage(sprite, 0, 0, GAME.player.width, GAME.player.height);
     ctx.restore();

--- a/settings.html
+++ b/settings.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>RuneDream - Settings</title>
   <link rel="manifest" href="manifest.json">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/upgrade.html
+++ b/upgrade.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>RuneDream - Upgrades</title>
   <link rel="manifest" href="manifest.json">
   <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
## Summary
- expand game container to fill the device screen
- set viewport-fit=cover across pages
- tweak player sprite draw offset for better ground alignment

## Testing
- `identify -format '%@' RuneDreamAssets/sprite_run_1.png`


------
https://chatgpt.com/codex/tasks/task_e_687d5382f40c832cb96c93d42c7f9a87